### PR TITLE
docs: Prepare 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-04
+
+### Added
+- Installing a plugin now installs the plugin's own declared dependencies into the host application, so packages the plugin relies on are available at runtime instead of failing with class-not-found
+- Local directory paths are a supported install source: `plugin:install ./path/to/plugin` copies the plugin into place, alongside the existing package-name and repository-URL sources
+- Dependency installation integrates with `wikimedia/composer-merge-plugin` when the host enables it, and otherwise installs the plugin's requirements directly
+
 ## [1.1.0] - 2026-06-07
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A flexible plugin engine for Laravel applications",
   "type": "library",
   "license": "proprietary",
-  "package-version": "1.1.0",
+  "version": "1.2.0",
   "autoload": {
     "psr-4": {
       "WhileSmart\\LaravelPluginEngine\\": "src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fddc38db5ede904f47f388b3a38bcac",
+    "content-hash": "b8ec48352185449cfd3fa7b9a3406d59",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
Cuts the 1.2.0 release, bringing the merged dependency-install work (#18) to `main`. Also switches the version marker to the standard `version` field.