### PR TITLE
chore: Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
   ],
   "require": {
     "php": "^8.1",
-    "illuminate/support": "^11.0",
-    "illuminate/console": "^11.0",
-    "illuminate/filesystem": "^11.0",
-    "illuminate/database": "^11.45"
+    "illuminate/support": "^11.0|^12.0",
+    "illuminate/console": "^11.0|^12.0",
+    "illuminate/filesystem": "^11.0|^12.0",
+    "illuminate/database": "^11.45|^12.0"
   },
   "require-dev": {
     "orchestra/testbench": "^9.0",


### PR DESCRIPTION
Updates illuminate dependencies to support both Laravel 11 and 12.

Required to update Trakli to Laravel 12